### PR TITLE
Update the lottery eligibility and logic for 2023 to be based on payment

### DIFF
--- a/fbsurvivor/core/management/commands/pick_lottery_winner.py
+++ b/fbsurvivor/core/management/commands/pick_lottery_winner.py
@@ -23,6 +23,12 @@ class Command(BaseCommand):
             p.username
             for p in players
             if not p.pick_set.filter(team__isnull=True, week__season=current_season)
+            and sum(
+                p.payout_set.filter(season=current_season).values_list(
+                    "amount", flat=True
+                )
+            )
+            < 30
         ]
         display = "\n".join(ep)
 

--- a/fbsurvivor/templates/rules.html
+++ b/fbsurvivor/templates/rules.html
@@ -2,7 +2,7 @@
     {% block content %}
         <h3>Rules</h3>
         <strong>Each Week</strong>:<br>
-        Pick one team to win. Ties are losses.<br>
+        Pick one team to win. Ties are losses. No contests are wins.<br>
         Submit your pick by the deadlines shown.<br>
         Your pick will lock at the deadline.<br>
         The week locks on Sunday at 1PM Eastern.<br>
@@ -15,7 +15,12 @@
         Survivor: at least 7x the buy in.<br>
         Best Record: 2-4x the buy in.<br>
         2nd Best Record: 1-2x the buy in.<br>
-        Players will split the corresponding payouts for ties.<br>
+        Lottery: Free play next season.<br><br>
+        To be eligible for the lottery:<br>
+        - don't be Dan<br>
+        - pick every week<br>
+        - amount won < buy in<br><br>
+        Players will split the corresponding payouts for ties in each category.<br>
         <br>
         Having issues? Email your pick to picks@fbsurvivor.com.
         <br><br>


### PR DESCRIPTION
Going to update the rules and logic for the lottery in 2023. This will remove complications due to ties in best record and so on. Stashing this in a PR for now since the 2022 rules do not limit the winner of the Second Best Record.